### PR TITLE
Add option support for webpack^2.1.0-beta.23

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function(source, inputSourceMap) {
   var filename = webpackRemainingChain[webpackRemainingChain.length - 1];
 
   // Handle options
-  var globalOptions = this.options.babel || {};
+  var globalOptions = this.babel || this.options.babel || {};
   var loaderOptions = loaderUtils.parseQuery(this.query);
   var userOptions = assign({}, globalOptions, loaderOptions);
   var defaultOptions = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Webpack^2.1.0-beta.23 would throw error saying `Invalid configuration object` if user uses global option `babel` in webpack config.

**What is the new behavior?**

We can now use global option by using loaderOptions plugin:

``` js
new webpack.LoaderOptionsPlugin({
  babel: {
    presets: ['es2015']
  }
})
```

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
